### PR TITLE
Transform data from API before it is passed to the components

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "date-fns": "^1.29.0",
     "object-path": "^0.11.4",
     "object-merge": "^2.5.1",
+    "stjs": "^0.0.5",
     "style-it": "^2.0.0"
   },
   "dependencies": {

--- a/src/components/Bus.js
+++ b/src/components/Bus.js
@@ -5,7 +5,6 @@ import {
   differenceInMilliseconds,
   differenceInMinutes,
 } from 'date-fns';
-import { get, set } from 'object-path';
 import * as locale from 'date-fns/locale/nb';
 import { DEBUG } from '../constants';
 
@@ -36,10 +35,10 @@ class Bus extends Component {
   componentWillReceiveProps(nextProps) {
     this.setState(
       Object.assign({}, this.state, {
-        toCity: get(nextProps, 'toCity', []),
-        fromCity: get(nextProps, 'fromCity', []),
-        toCity2: get(nextProps, 'toCity2', []),
-        fromCity2: get(nextProps, 'fromCity2', []),
+        toCity: nextProps.toCity || [],
+        fromCity: nextProps.fromCity || [],
+        toCity2: nextProps.toCity2 || [],
+        fromCity2: nextProps.fromCity2 || [],
       }),
     );
   }
@@ -50,41 +49,13 @@ class Bus extends Component {
     let diff = differenceInMilliseconds(new Date(), this.state.lastTick);
 
     for (let departure of toCity) {
-      set(
-        departure,
-        this.props.departureSchema.registredTime,
-        this.addTime(
-          get(departure, this.props.departureSchema.registredTime),
-          diff,
-        ),
-      );
-      set(
-        departure,
-        this.props.departureSchema.scheduledTime,
-        this.addTime(
-          get(departure, this.props.departureSchema.scheduledTime),
-          diff,
-        ),
-      );
+      departure.registeredTime = this.addTime(departure.registeredTime, diff);
+      departure.scheduledTime = this.addTime(departure.scheduledTime, diff);
     }
 
     for (let departure of fromCity) {
-      set(
-        departure,
-        this.props.departureSchema.registredTime,
-        this.addTime(
-          get(departure, this.props.departureSchema.registredTime),
-          diff,
-        ),
-      );
-      set(
-        departure,
-        this.props.departureSchema.scheduledTime,
-        this.addTime(
-          get(departure, this.props.departureSchema.scheduledTime),
-          diff,
-        ),
-      );
+      departure.registeredTime = this.addTime(departure.registeredTime, diff);
+      departure.scheduledTime = this.addTime(departure.scheduledTime, diff);
     }
 
     if (this.mounted) {
@@ -106,15 +77,15 @@ class Bus extends Component {
   getDepartureList(departures) {
     return departures
       .map(e => {
-        e.time = get(e, this.props.departureSchema.scheduledTime);
+        e.time = e.scheduledTime;
 
-        if (get(e, this.props.departureSchema.isRealtime)) {
-          e.time = get(e, this.props.departureSchema.registredTime);
+        if (e.isRealtime) {
+          e.time = e.registeredTime;
         }
 
         return e;
       })
-      .filter(e => !/^FB/.test(get(e, this.props.departureSchema.number)))
+      .filter(e => !/^FB/.test(e.number))
       .sort((a, b) => new Date(a.time).getTime() - new Date(b.time).getTime())
       .filter(
         e =>
@@ -123,7 +94,7 @@ class Bus extends Component {
       )
       .slice(0, 4)
       .map((e, i) => {
-        const isRealtime = get(e, this.props.departureSchema.isRealtime);
+        const isRealtime = e.isRealtime;
         const timeLeft = differenceInMinutes(e.time, new Date(), { locale });
         let time = isRealtime ? '' : '';
         const isClose = timeLeft <= 11;
@@ -141,17 +112,13 @@ class Bus extends Component {
         const style = isClose ? { color: '#ffb800' } : {};
 
         return (
-          <div
-            key={i}
-            title={get(e, this.props.departureSchema.name)}
-            className="bus-list-item"
-          >
+          <div key={i} title={e.name} className="bus-list-item">
             <div
               className={`bus-list-item-number${isClose ? ' is-close' : ''}${
                 isRealtime ? ' is-realtime' : ''
               }`}
             >
-              {get(e, this.props.departureSchema.number)}
+              {e.number}
               &nbsp;
             </div>
             <div className="bus-list-item-time" style={style}>

--- a/src/components/Events.js
+++ b/src/components/Events.js
@@ -1,5 +1,4 @@
 import React, { Component } from 'react';
-import { get } from 'object-path';
 import { format } from 'date-fns';
 
 export default class Events extends Component {
@@ -15,14 +14,14 @@ export default class Events extends Component {
       default:
         EventsUI = EventsCarousel;
     }
-    const { events = [], eventMapping } = this.props;
+    const { events = [] } = this.props;
     const eventsMapped = events.map(e => {
-      const startDateTime = get(e, eventMapping.startDate, '');
+      const startDateTime = e.startDate;
       const startDate = format(startDateTime, 'dddd D. MMM');
       const startTime = format(startDateTime, 'HH:MM');
-      const title = get(e, eventMapping.title, '');
-      const image = get(e, eventMapping.image, '');
-      const companyImage = get(e, eventMapping.companyImage, '');
+      const title = e.title;
+      const image = e.image;
+      const companyImage = e.companyImage;
 
       return {
         startDate,

--- a/src/defaults/affiliations.js
+++ b/src/defaults/affiliations.js
@@ -77,16 +77,9 @@ export const defaultAffiliationSettings = {
       {
         template: 'Events',
         type: '{{eventType}}',
-        eventMapping: {
-          startDate: 'event_start',
-          endDate: 'event_end',
-          title: 'title',
-          image: 'image.wide',
-          companyImage: 'company_event.0.company.image.wide',
-        },
         imageHost: 'https://online.ntnu.no',
         apis: {
-          events: 'onlineEvents:results',
+          events: 'onlineEvents:events',
         },
         css: '.Events { padding-bottom: 0; }',
       },

--- a/src/defaults/affiliations.js
+++ b/src/defaults/affiliations.js
@@ -18,7 +18,7 @@ export const defaultAffiliationSettings = {
         departureSchema: {
           name: 'destination',
           number: 'line',
-          registredTime: 'registeredDepartureTime',
+          registeredTime: 'registeredDepartureTime',
           scheduledTime: 'scheduledDepartureTime',
           isRealtime: 'isRealtimeData',
         },
@@ -58,13 +58,6 @@ export const defaultAffiliationSettings = {
       {
         template: 'Bus',
         name: '{{bus}}',
-        departureSchema: {
-          name: 'destination',
-          number: 'line',
-          registredTime: 'registeredDepartureTime',
-          scheduledTime: 'scheduledDepartureTime',
-          isRealtime: 'isRealtimeData',
-        },
         apis: {
           fromCity: 'tarbus.stops.{{bus:glossyd}}.fromCity:departures',
           toCity: 'tarbus.stops.{{bus:glossyd}}.toCity:departures',
@@ -74,18 +67,9 @@ export const defaultAffiliationSettings = {
         template: 'Bus',
         id: 'Bus2',
         name: '{{bus2}}',
-        departureSchema: {
-          name: 'destinationDisplay.frontText',
-          number: 'serviceJourney.line.publicCode',
-          registredTime: 'aimedArrivalTime',
-          scheduledTime: 'expectedArrivalTime',
-          isRealtime: 'realtime',
-        },
         apis: {
-          fromCity:
-            'enturbus.stops.{{bus2:prof}}.fromCity:data.quay.estimatedCalls',
-          toCity:
-            'enturbus.stops.{{bus2:prof}}.toCity:data.quay.estimatedCalls',
+          fromCity: 'enturbus.stops.{{bus2:prof}}.fromCity:departures',
+          toCity: 'enturbus.stops.{{bus2:prof}}.toCity:departures',
         },
       },
       {

--- a/src/defaults/affiliations.js
+++ b/src/defaults/affiliations.js
@@ -15,13 +15,7 @@ export const defaultAffiliationSettings = {
       },
       {
         template: 'Bus',
-        departureSchema: {
-          name: 'destination',
-          number: 'line',
-          registeredTime: 'registeredDepartureTime',
-          scheduledTime: 'scheduledDepartureTime',
-          isRealtime: 'isRealtimeData',
-        },
+        name: '{{bus}}',
         apis: {
           fromCity: 'tarbus.stops.{{bus:glossyd}}.fromCity:departures',
           toCity: 'tarbus.stops.{{bus:glossyd}}.toCity:departures',

--- a/src/defaults/apis.js
+++ b/src/defaults/apis.js
@@ -105,5 +105,16 @@ export const defaultApis = {
   onlineEvents: {
     interval: 100,
     url: 'https://online.ntnu.no/api/v1/events/',
+    transform: {
+      events: {
+        '{{#each results}}': {
+          startDate: '{{event_start}}',
+          endDate: '{{event_end}}',
+          title: '{{title}}',
+          image: '{{image.wide}}',
+          companyImage: '{{company_event.0.company.image.wide}}',
+        },
+      },
+    },
   },
 };

--- a/src/defaults/apis.js
+++ b/src/defaults/apis.js
@@ -29,6 +29,18 @@ export const defaultApis = {
       samf: { fromCity: '16010476', toCity: '16011476' },
       prof: { fromCity: '16010376', toCity: '16011376' },
     },
+    // Using STJS for object mapping (https://www.npmjs.com/package/stjs#2-transform)
+    transform: {
+      departures: {
+        '{{#each departures}}': {
+          name: '{{destination}}',
+          number: '{{line}}',
+          registredTime: '{{registeredDepartureTime}}',
+          scheduledTime: '{{scheduledDepartureTime}}',
+          isRealtime: '{{isRealtimeData}}',
+        },
+      },
+    },
   },
   bartebuss: {
     interval: 10,
@@ -49,7 +61,7 @@ export const defaultApis = {
       },
       mode: 'cors',
     },
-    body: JSON.stringify({
+    body: {
       query: `{
         quay(id: "NSR:Quay:{{stops.*.fromCity,toCity}}") {
           id
@@ -72,11 +84,22 @@ export const defaultApis = {
           }
         }
       }`,
-    }),
+    },
     stops: {
       glossyd: { fromCity: '75707', toCity: '75708' },
       samf: { fromCity: '73103', toCity: '73101' },
       prof: { fromCity: '73103', toCity: '73101' },
+    },
+    transform: {
+      departures: {
+        '{{#each data.quay.estimatedCalls}}': {
+          name: '{{destinationDisplay.frontText}}',
+          number: '{{serviceJourney.line.publicCode}}',
+          registredTime: '{{aimedArrivalTime}}',
+          scheduledTime: '{{expectedArrivalTime}}',
+          isRealtime: '{{realtime}}',
+        },
+      },
     },
   },
   onlineEvents: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7561,6 +7561,10 @@ stealthy-require@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
 
+stjs@^0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/stjs/-/stjs-0.0.5.tgz#3e594645ccb41fb97b80b279093e2f9e4fb1738e"
+
 stream-browserify@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/stream-browserify/-/stream-browserify-2.0.1.tgz#66266ee5f9bdb9940a4e4514cafb43bb71e5c9db"


### PR DESCRIPTION
Make it possible to transform the output result from every API. This can be used to for example unify the way the Bus component gets its data from the APIs. Bus APIs has the same data, but mapped in a different way. Making each API responsible for transforming its output will make it a lot easier for components that uses its data.

Now each bus API returns this result to its components:
```json
{
    "departures": [
        {
            "name": "...",
            "number": "...",
            "registredTime": "...",
            "scheduledTime": "...",
            "isRealtime": "...",
        },
        "..."
    ]
}
```