### PR TITLE
Make it possible to scrape inside data mapping functions

### DIFF
--- a/src/services/APIService.js
+++ b/src/services/APIService.js
@@ -107,22 +107,19 @@ transform('https://some.api/api?date=[[now.date]]') => 'https://some.api/api?dat
             this.usedApis[key] &&
             this.hasNotFailed(key)
           ) {
-            const urlTransformed = this.transform(url);
-            const [coreUrl, method = 'GET', body = ''] = urlTransformed.split(
-              '#',
-            );
             const callback = data => {
               if ('error' in data) {
                 this.handleFail(key, apiName);
               } else {
                 if ('print' in api && api.print) {
-                  console.log(data);
+                  console.log(`Fra ${key}:`, data);
                 }
                 if ('transform' in api) {
                   const transformedData = ST.select(data)
                     .transformWith(api.transform)
                     .root();
-                  this.callback(key, transformedData);
+                  const { scrape } = api;
+                  this.callback(key, transformedData, scrape);
                 } else {
                   this.callback(key, data);
                 }
@@ -131,21 +128,8 @@ transform('https://some.api/api?date=[[now.date]]') => 'https://some.api/api?dat
             const error = () => {
               this.handleFail(key, apiName);
             };
-            switch (method) {
-              case 'GET':
-                API.getRequest(coreUrl, api.request || {}, callback, error);
-                break;
-              case 'POST':
-                const req = Object.assign({ body }, api.request || {});
-                API.postRequest(coreUrl, req, callback, error);
-                break;
-              case 'RSS':
-                API.getRSSRequest(coreUrl, api.request || {}, callback, error);
-                break;
-              default:
-                API.getRequest(coreUrl, api.request || {}, callback, error);
-                break;
-            }
+            const urlTransformed = this.transform(url);
+            this.request(urlTransformed, api.request || {}, callback, error);
           }
         });
       }
@@ -209,6 +193,49 @@ transform('https://some.api/api?date=[[now.date]]') => 'https://some.api/api?dat
 
   updateSettings(settings) {
     this.settings = settings;
+  }
+
+  scrape(path, data, callback) {
+    const selectors = findObjectPaths(data, path);
+    for (const selector of selectors) {
+      const string = get(data, selector, '');
+      const scrapeSections = getStringParams(string, '[[', ']]');
+      for (const section of scrapeSections) {
+        const selectorIndex = section.indexOf(':', 7);
+        const req = section.slice(0, selectorIndex);
+        const htmlSelector = section.slice(selectorIndex + 1);
+        this.request(req, { htmlSelector }, scrapeData => {
+          callback(scrapeData, selector, section);
+        });
+      }
+    }
+  }
+
+  request(url, req, callback, error) {
+    const [coreUrl, type = 'GET', body = ''] = url.split('#');
+    switch (type) {
+      case 'GET':
+        API.getRequest(coreUrl, req, callback, error);
+        break;
+      case 'POST':
+        const newReq = Object.assign({ body }, req);
+        API.postRequest(coreUrl, newReq, callback, error);
+        break;
+      case 'RSS':
+        API.getRSSRequest(coreUrl, req, callback, error);
+        break;
+      case 'HTML':
+        const { htmlSelector } = req;
+        delete req.htmlSelector;
+        API.getHTMLRequest(coreUrl, htmlSelector, req, callback, error);
+        break;
+      case 'TEXT':
+        API.getTextRequest(coreUrl, req, callback, error);
+        break;
+      default:
+        API.getRequest(url, req, callback, error);
+        break;
+    }
   }
 
   /**

--- a/src/utils/algorithms.js
+++ b/src/utils/algorithms.js
@@ -152,10 +152,11 @@ injectValuesIntoString('{{five:def}}test{{six:ault}}', obj, '', '{{', '}}') => '
 injectValuesIntoString('{{five:def}}test{{four:ault}}', obj, '', '{{', '}}') => 'deftest4'
  * ```
  * @param {string} string The String to search through
- * @param {string} values An object with all values that can fit the keys
+ * @param {object} values An object with all values that can fit the keys
  * @param {string} fallbackValue Default value if no keys in values matches
  * @param {string} start Start of match
  * @param {string} end End of match
+ * @param {string} defaultMatch How to split default values
  *
  * @returns {string} Generated string
  */
@@ -165,6 +166,7 @@ export const injectValuesIntoString = (
   fallbackValue = null,
   start = '{{',
   end = '}}',
+  defaultMatch = ':',
 ) => {
   const params = getStringParams(string, start, end);
 
@@ -185,8 +187,8 @@ export const injectValuesIntoString = (
       } else {
         value = values[param];
       }
-    } else if (~param.indexOf(':')) {
-      const [extractedParam, defaultVal] = param.split(':');
+    } else if (~param.indexOf(defaultMatch)) {
+      const [extractedParam, defaultVal] = param.split(defaultMatch);
       if (extractedParam in values) {
         value = values[extractedParam];
       } else {

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -43,7 +43,7 @@ export const API = {
   },
 
   /**
-   * Send a GET request and parse RSS.
+   * Send a GET request, resolve CORS and parse RSS.
    *
    * @param {string} url The URL to GET from
    * @param {object} req Headers and more request spesific (see the fetch API)
@@ -59,6 +59,47 @@ export const API = {
           callback(parsedResult);
         });
       })
+      .catch(error);
+  },
+
+  /**
+   * Send a GET request and resolve CORS.
+   *
+   * @param {string} url The URL to GET from
+   * @param {object} req Headers and more request spesific (see the fetch API)
+   * @param {function} callback Function that retrieves data from request
+   * @param {function} error Error from when request fails
+   */
+  getHTMLRequest(url, selector, req, callback = () => {}, error = () => {}) {
+    const CORS_PROXY = 'https://cors-anywhere.herokuapp.com/';
+    return fetch(API.transformURL(CORS_PROXY + url), req)
+      .then(res => res.text())
+      .then(html => {
+        const parser = new DOMParser();
+        const doc = parser.parseFromString(html, 'text/html');
+        const [querySelector = 'html', attribute = ''] = selector.split('@');
+        const element = doc.querySelector(querySelector);
+        const scrapeData = attribute
+          ? element.getAttribute(attribute)
+          : element.innerHTML;
+        callback(scrapeData);
+      })
+      .catch(error);
+  },
+
+  /**
+   * Send a GET request and resolve CORS.
+   *
+   * @param {string} url The URL to GET from
+   * @param {object} req Headers and more request spesific (see the fetch API)
+   * @param {function} callback Function that retrieves data from request
+   * @param {function} error Error from when request fails
+   */
+  getTextRequest(url, req, callback = () => {}, error = () => {}) {
+    const CORS_PROXY = 'https://cors-anywhere.herokuapp.com/';
+    return fetch(API.transformURL(CORS_PROXY + url), req)
+      .then(res => res.text())
+      .then(callback)
       .catch(error);
   },
 


### PR DESCRIPTION
Sometimes it is essential to get an image from an article, but the RSS feed or API only has the canonical link to the article and not the image. To solve this, we can send an extra request to that canonical url, fetch the image `src` attribute, then place the `src` url into the component.

Works like this, using Dusken as an example:
```javascript
dusken: {
    interval: ...,
    url: 'https://dusken.no/feed#RSS',

    // Tell the app to scrape this transform value
    scrape: ['articles.*.image'],

    // The transform function
    transform: {
      articles: {
        '{{#each rss.channel[0].item}}': {
          title: '{{title[0]}}',
          date: '{{pubDate[0]}}',
          link: '{{link[0]}}',
          author: 'Dusken.no',

          // Inject data from inside the #header-img src attribute in {{link[0]}}.
          image: 'http://dusken.no[[{{link[0]}}#HTML:#header-img@src]]',
        },
      },
    },
  },
```

Fix #38 and #37 