### PR TITLE
Add NTNUI affiliation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 ![NotiStar](https://i.imgur.com/i78hOG1.png)
-[![Drone Status](https://ci.online.ntnu.no/api/badges/dotkom/the-notifier-awakens/status.svg?ref=/refs/heads/master)](https://ci.online.ntnu.no/dotkom/the-notifier-awakens)
 
 <!--![Storytime](https://i.imgur.com/ZXXFkQM.png)-->
 

--- a/src/components/Events.js
+++ b/src/components/Events.js
@@ -14,6 +14,9 @@ export default class Events extends Component {
       case 'carousel':
         EventsUI = EventsCarousel;
         break;
+      case 'timeline':
+        EventsUI = EventsTimeline;
+        break;
       default:
         EventsUI = EventsFromSplash;
     }
@@ -277,6 +280,128 @@ class EventsCarousel extends Component {
           </span>
         </div>
         <div className="event-list">{eventList}</div>
+      </>
+    );
+  }
+}
+
+class EventsTimeline extends Component {
+  render() {
+    const { dark = true } = this.props;
+    const {
+      events = [],
+      lineColor = dark ? '#ddd' : '#888',
+      dateColor = dark ? '#f80' : '#f80',
+      timeColor = dark ? 'rgba(160, 160, 160, .8)' : '#888',
+      textColor = dark ? '#ccc' : '#666',
+      IfPropIsOnline,
+    } = this.props;
+    let prevStartDate = '';
+    const eventList = events.slice(0).map((e, i) => {
+      const { startDateFormatted, startTimeFormatted, title, hasTime } = e;
+      const style = {};
+      let skipDate = false;
+      if (prevStartDate !== startDateFormatted || i === 0) {
+        skipDate = true;
+        prevStartDate = startDateFormatted;
+      }
+
+      return (
+        <div key={i} className="event event-splash" style={style}>
+          <span className="start-date">
+            {skipDate ? startDateFormatted : ''}
+          </span>
+          <span className="time-element">
+            <span className="start-time">
+              {hasTime ? startTimeFormatted : ''}
+            </span>
+            <span className="title">{title}</span>
+          </span> 
+        </div>
+      );
+    });
+
+    return (
+      <>
+        <style>
+          {`
+          .event-list {
+            display: flex;
+            flex-direction: column;
+            max-width: 625px;
+            margin: auto;
+            margin-bottom: -32px;
+            color: ${textColor};
+          }
+          .event {
+            display: flex;
+            flex-wrap: nowrap;
+          }
+          @media (max-width: 640px) {
+            .event {
+              flex-wrap: wrap;
+            }
+            .time-element {
+              min-width: 100%;
+            }
+          }
+          .time-element {
+            order: 2;
+            display: flex;
+            flex-flow: row nowrap;
+            flex: 1;
+          }
+          .title {
+            order: 3;
+            flex: 1 1 auto;
+            position: relative;
+            border-left: 3px solid ${lineColor};
+            padding: 10px 0 10px 42px;
+          }
+          .title::before {
+            content: '';
+            position: absolute;
+            right: calc(100% - 5px);
+            top: 18px;
+            background-color: ${lineColor};
+            width: 14px;
+            height: 14px;
+            border-radius: 7px;
+          }
+          .event:last-child .title {
+            padding-bottom: 32px;
+          }
+          .start-date:first-letter {
+            text-transform: capitalize;
+          }
+          .start-date:empty {
+            padding: 0;
+          }
+          .start-date {
+            order: 1;
+            flex: 0 0 215px;
+            text-align: right;
+            color: ${dateColor};
+            padding: 10px 0;
+          }
+          .start-time {
+            order: 2;
+            flex: 0 0 80px;
+            text-align: center;
+            font-size: .75em;
+            color: ${timeColor};
+            padding: 14px 10px 10px 0;
+          }
+          `}
+        </style>
+        <IfPropIsOnline
+          prop="events"
+          props={this.props}
+          else={apiName => `Kunne ikke koble til ${apiName}`}
+          loading={<Loading />}
+        >
+          <div className="event-list">{eventList}</div>
+        </IfPropIsOnline>
       </>
     );
   }

--- a/src/defaults/affiliations.js
+++ b/src/defaults/affiliations.js
@@ -417,6 +417,57 @@ export const defaultAffiliationSettings = {
     color: 'blue',
     components: [],
   },
+  ntnui: {
+    name: 'NTNUI',
+    color: '#00843D',
+    layouts: {
+      0: ['Logo Date Bus',
+          'Events Events Bus',
+          'Events Events Bus',
+          'Events Events Bus',
+          'Events Events Bike',
+          'Events Events Bike',
+          'Events Events Bike',
+        ],
+    },
+    components: [
+      {
+        template: 'Logo',
+        url: 'https://photos.smugmug.com/photos/i-DTr3wpH/0/X4/i-DTr3wpH-X4.png',
+      },
+      {
+        template: 'Date',
+        apis: { time: 'seconds' } 
+      },
+      {
+        template: 'Bus',
+        name: '{{bus:hogs}}',
+        count: '10',
+        css: '.Bus > .bus-wrapper {background-color: #00843D;} .Bus {font-size: 30px;}',
+        apis: {
+          fromCity:
+            '{{busApi:enturbus}}.stops.{{bus:hogs}}.toCity.stops.{{bus:hogs}}.fromCity:from',
+          toCity:
+            '{{busApi:enturbus}}.stops.{{bus:hogs}}.toCity.stops.{{bus:hogs}}.fromCity:to',
+        },
+      },
+      {
+        template: 'Bike',
+        id: 'Bike',
+        names: ['Klubbhuset', 'Hovedbygget'],
+        apis: {
+          stations: 'trondheimCityBikeNTNUI:stations',
+        },
+        css: '.Bike {font-size: 30px; font-family: Righteous;}',
+      },
+      {
+      template: 'Events',
+      type: 'timeline',
+      count: '12',
+      css: '.event-list {margin: unset; margin-left: 24.5%; max-width: 900px; font-size: 28px; font-family: Righteous;} .start-date {color: rgb(254, 219, 0);}',
+      }
+    ],
+  },
   nutrix: {
     name: 'Nutrix',
     color: 'green',

--- a/src/defaults/apis.js
+++ b/src/defaults/apis.js
@@ -238,6 +238,7 @@ export const defaultApis = {
       samf: { fromCity: '16010476', toCity: '16011476' },
       prof: { fromCity: '16010376', toCity: '16011376' },
       magn: { fromCity: '16010290', toCity: '16011290' },
+      hogs: { fromCity: '16010197', toCity: '16011197' },
     },
     transform: {
       departures: {
@@ -327,6 +328,7 @@ export const defaultApis = {
       hest: { fromCity: '71204', toCity: '102719' },
       samf: { fromCity: '73103', toCity: '73101' },
       prof: { fromCity: '71204', toCity: '71195' },
+      hogs: { fromCity: '71939', toCity: '71940' },
     },
     transform: {
       from: {
@@ -445,6 +447,26 @@ export const defaultApis = {
       },
     },
   },
+  trondheimCityBikeNTNUI: {
+    interval: 60,
+    url:
+      'https://gbfs.urbansharing.com/trondheimbysykkel.no/station_status.json',
+    cors: true,
+    request: {
+      headers: {
+        'Client-Identifier': 'onlinentnu-notifier-dev',
+      },
+    },
+    transform: {
+      stations: {
+        '{{#each data.stations.filter(a => a.station_id === "1878" || a.station_id === "94")}}': {
+          id: '{{station_id}}',
+          bikes: '{{num_bikes_available}}',
+          docks: '{{num_docks_available}}',
+        },
+      },
+    },
+  },
   trondheimCityBikeGraphQL: {
     interval: 60,
     url: 'https://core.urbansharing.com/public/api/v1/graphql#POST',
@@ -535,6 +557,20 @@ export const defaultApis = {
         title: '{{header["#text"]}}',
       },
     },
+  },
+  ntnuiEvents: {
+    interval: 10,
+    url:
+      'https://ntnui.no/kalender/feed/#RSS',
+      transform: {
+        events: {
+          '{{#each rss.channel[0].item}}': {
+            startDate: '{{pubDate}}',
+            // endDate: '{{end}}',
+            title: '{{title[0]}}',
+          },
+        },
+      },
   },
   smorekoppenEvents: {
     interval: 100,

--- a/src/defaults/translations.js
+++ b/src/defaults/translations.js
@@ -5,6 +5,7 @@ export const defaultTranslations = {
   samf: 'Samfundet',
   prof: 'Professor Brochs gate',
   hest: 'Hesthagen',
+  hogs: 'Høgskoleringen',
   tarbus: 'Tarbus.no',
   enturbus: 'Entur.no',
   affiliation: 'Gruppe',


### PR DESCRIPTION
- Add new Event UI `Timeline`, same as `EventsFromSplash` without the first event looking like header text
- Add affiliation and related APIs for NTNUI
- Remove broken image from README.md